### PR TITLE
Updated tcp_handler interface to match latest (but didn't implement anything new)

### DIFF
--- a/rosbridge_server/launch/rosbridge_tcp_launch.xml
+++ b/rosbridge_server/launch/rosbridge_tcp_launch.xml
@@ -11,6 +11,8 @@
   <arg name="max_message_size" default="None" />
   <arg name="unregister_timeout" default="10" />
 
+  <arg name="call_services_in_new_thread" default="false" />
+
   <arg name="topics_glob" default="" />
   <arg name="services_glob" default="" />
   <arg name="params_glob" default="" />
@@ -26,6 +28,7 @@
     <param name="delay_between_messages" value="$(var delay_between_messages)"/>
     <param name="max_message_size" value="$(var max_message_size)"/>
     <param name="unregister_timeout" value="$(var unregister_timeout)"/>
+    <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
 
     <param name="topics_glob" value="$(var topics_glob)"/>
     <param name="services_glob" value="$(var services_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_tcp
+++ b/rosbridge_server/scripts/rosbridge_tcp
@@ -68,6 +68,7 @@ class RosbridgeTcpsocketNode(Node):
         max_message_size = self.declare_parameter('max_message_size', RosbridgeTcpSocket.max_message_size).value
         # unregister_timeout = get_param('~unregister_timeout', RosbridgeTcpSocket.unregister_timeout)
         unregister_timeout = self.declare_parameter('unregister_timeout', RosbridgeTcpSocket.unregister_timeout).value
+        call_services_in_new_thread = self.declare_parameter("call_services_in_new_thread", False).value        
         # bson_only_mode = get_param('~bson_only_mode', False)
         bson_only_mode = self.declare_parameter('bson_only_mode', RosbridgeTcpSocket.bson_only_mode).value
         

--- a/rosbridge_server/src/rosbridge_server/__init__.py
+++ b/rosbridge_server/src/rosbridge_server/__init__.py
@@ -1,2 +1,3 @@
 from .client_mananger import ClientManager  # noqa: F401
 from .websocket_handler import RosbridgeWebSocket  # noqa: F401
+from .tcp_handler import RosbridgeTcpSocket  # noqa: F401


### PR DESCRIPTION
I tried getting your tcp_handler working with the latest RobotWebTools:ros2 branch but was unable to take it over the finish line. These changes are a step in the right direction.

This patch enables it to launch and appears to work with one client, but I'm unable to get two clients to connect. The second client will seem to connect but do nothing until the first disconnects. 

* compressed data -> client should work.
* `call_services_in_new_thread` is unimplemented (but the parameter needs to exist).

